### PR TITLE
[flutter_appauth] Support nonce for AuthorizationRequest (iOS, Android, Mac)

### DIFF
--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -211,8 +211,9 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
         Map<String, String> additionalParameters = (Map<String, String>) arguments.get("additionalParameters");
         allowInsecureConnections = (boolean) arguments.get("allowInsecureConnections");
         final String responseMode = (String) arguments.get("responseMode");
+        final String nonce = (String) arguments.get("nonce");
 
-        return new AuthorizationTokenRequestParameters(clientId, issuer, discoveryUrl, scopes, redirectUrl, serviceConfigurationParameters, additionalParameters, loginHint, promptValues, responseMode);
+        return new AuthorizationTokenRequestParameters(clientId, issuer, discoveryUrl, scopes, redirectUrl, serviceConfigurationParameters, additionalParameters, loginHint, promptValues, responseMode, nonce);
     }
 
     @SuppressWarnings("unchecked")
@@ -263,13 +264,13 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
         final AuthorizationTokenRequestParameters tokenRequestParameters = processAuthorizationTokenRequestArguments(arguments);
         if (tokenRequestParameters.serviceConfigurationParameters != null) {
             AuthorizationServiceConfiguration serviceConfiguration = processServiceConfigurationParameters(tokenRequestParameters.serviceConfigurationParameters);
-            performAuthorization(serviceConfiguration, tokenRequestParameters.clientId, tokenRequestParameters.redirectUrl, tokenRequestParameters.scopes, tokenRequestParameters.loginHint, tokenRequestParameters.additionalParameters, exchangeCode, tokenRequestParameters.promptValues, tokenRequestParameters.responseMode);
+            performAuthorization(serviceConfiguration, tokenRequestParameters.clientId, tokenRequestParameters.redirectUrl, tokenRequestParameters.scopes, tokenRequestParameters.loginHint, tokenRequestParameters.additionalParameters, exchangeCode, tokenRequestParameters.promptValues, tokenRequestParameters.responseMode, tokenRequestParameters.nonce);
         } else {
             AuthorizationServiceConfiguration.RetrieveConfigurationCallback callback = new AuthorizationServiceConfiguration.RetrieveConfigurationCallback() {
                 @Override
                 public void onFetchConfigurationCompleted(@Nullable AuthorizationServiceConfiguration serviceConfiguration, @Nullable AuthorizationException ex) {
                     if (ex == null) {
-                        performAuthorization(serviceConfiguration, tokenRequestParameters.clientId, tokenRequestParameters.redirectUrl, tokenRequestParameters.scopes, tokenRequestParameters.loginHint, tokenRequestParameters.additionalParameters, exchangeCode, tokenRequestParameters.promptValues, tokenRequestParameters.responseMode);
+                        performAuthorization(serviceConfiguration, tokenRequestParameters.clientId, tokenRequestParameters.redirectUrl, tokenRequestParameters.scopes, tokenRequestParameters.loginHint, tokenRequestParameters.additionalParameters, exchangeCode, tokenRequestParameters.promptValues, tokenRequestParameters.responseMode, tokenRequestParameters.nonce);
                     } else {
                         finishWithDiscoveryError(ex);
                     }
@@ -313,7 +314,7 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
     }
 
 
-    private void performAuthorization(AuthorizationServiceConfiguration serviceConfiguration, String clientId, String redirectUrl, ArrayList<String> scopes, String loginHint, Map<String, String> additionalParameters, boolean exchangeCode, ArrayList<String> promptValues, String responseMode) {
+    private void performAuthorization(AuthorizationServiceConfiguration serviceConfiguration, String clientId, String redirectUrl, ArrayList<String> scopes, String loginHint, Map<String, String> additionalParameters, boolean exchangeCode, ArrayList<String> promptValues, String responseMode, String nonce) {
         AuthorizationRequest.Builder authRequestBuilder =
                 new AuthorizationRequest.Builder(
                         serviceConfiguration,
@@ -335,6 +336,10 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
 
         if (responseMode != null) {
             authRequestBuilder.setResponseMode(responseMode);
+        }
+
+        if (nonce != null) {
+            authRequestBuilder.setNonce(nonce);
         }
 
         if (additionalParameters != null && !additionalParameters.isEmpty()) {
@@ -644,8 +649,8 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
         final ArrayList<String> promptValues;
         final String responseMode;
 
-        private AuthorizationTokenRequestParameters(String clientId, String issuer, String discoveryUrl, ArrayList<String> scopes, String redirectUrl, Map<String, String> serviceConfigurationParameters, Map<String, String> additionalParameters, String loginHint, ArrayList<String> promptValues, String responseMode) {
-            super(clientId, issuer, discoveryUrl, scopes, redirectUrl, null, null, null, null, null, serviceConfigurationParameters, additionalParameters);
+        private AuthorizationTokenRequestParameters(String clientId, String issuer, String discoveryUrl, ArrayList<String> scopes, String redirectUrl, Map<String, String> serviceConfigurationParameters, Map<String, String> additionalParameters, String loginHint, ArrayList<String> promptValues, String responseMode, String nonce) {
+            super(clientId, issuer, discoveryUrl, scopes, redirectUrl, null, null, null, nonce, null, serviceConfigurationParameters, additionalParameters);
             this.loginHint = loginHint;
             this.promptValues = promptValues;
             this.responseMode = responseMode;

--- a/flutter_appauth/example/lib/main.dart
+++ b/flutter_appauth/example/lib/main.dart
@@ -1,4 +1,5 @@
 import 'dart:io' show Platform;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_appauth/flutter_appauth.dart';
 import 'package:http/http.dart' as http;
@@ -20,35 +21,23 @@ class _MyAppState extends State<MyApp> {
   String? _accessToken;
   String? _idToken;
 
-  final TextEditingController _authorizationCodeTextController =
-      TextEditingController();
-  final TextEditingController _accessTokenTextController =
-      TextEditingController();
-  final TextEditingController _accessTokenExpirationTextController =
-      TextEditingController();
+  final TextEditingController _authorizationCodeTextController = TextEditingController();
+  final TextEditingController _accessTokenTextController = TextEditingController();
+  final TextEditingController _accessTokenExpirationTextController = TextEditingController();
 
   final TextEditingController _idTokenTextController = TextEditingController();
-  final TextEditingController _refreshTokenTextController =
-      TextEditingController();
+  final TextEditingController _refreshTokenTextController = TextEditingController();
   String? _userInfo;
 
   // For a list of client IDs, go to https://demo.duendesoftware.com
   final String _clientId = 'interactive.public';
   final String _redirectUrl = 'com.duendesoftware.demo:/oauthredirect';
   final String _issuer = 'https://demo.duendesoftware.com';
-  final String _discoveryUrl =
-      'https://demo.duendesoftware.com/.well-known/openid-configuration';
+  final String _discoveryUrl = 'https://demo.duendesoftware.com/.well-known/openid-configuration';
   final String _postLogoutRedirectUrl = 'com.duendesoftware.demo:/';
-  final List<String> _scopes = <String>[
-    'openid',
-    'profile',
-    'email',
-    'offline_access',
-    'api'
-  ];
+  final List<String> _scopes = <String>['openid', 'profile', 'email', 'offline_access', 'api'];
 
-  final AuthorizationServiceConfiguration _serviceConfiguration =
-      const AuthorizationServiceConfiguration(
+  final AuthorizationServiceConfiguration _serviceConfiguration = const AuthorizationServiceConfiguration(
     authorizationEndpoint: 'https://demo.duendesoftware.com/connect/authorize',
     tokenEndpoint: 'https://demo.duendesoftware.com/connect/token',
     endSessionEndpoint: 'https://demo.duendesoftware.com/connect/endsession',
@@ -92,8 +81,7 @@ class _MyAppState extends State<MyApp> {
                         'Sign in with auto code exchange using ephemeral session',
                         textAlign: TextAlign.center,
                       ),
-                      onPressed: () => _signInWithAutoCodeExchange(
-                          preferEphemeralSession: true),
+                      onPressed: () => _signInWithAutoCodeExchange(preferEphemeralSession: true),
                     ),
                   ),
                 ElevatedButton(
@@ -172,9 +160,8 @@ class _MyAppState extends State<MyApp> {
   Future<void> _refresh() async {
     try {
       _setBusyState();
-      final TokenResponse? result = await _appAuth.token(TokenRequest(
-          _clientId, _redirectUrl,
-          refreshToken: _refreshToken, issuer: _issuer, scopes: _scopes));
+      final TokenResponse? result = await _appAuth
+          .token(TokenRequest(_clientId, _redirectUrl, refreshToken: _refreshToken, issuer: _issuer, scopes: _scopes));
       _processTokenResponse(result);
       await _testApi(result);
     } catch (_) {
@@ -185,8 +172,7 @@ class _MyAppState extends State<MyApp> {
   Future<void> _exchangeCode() async {
     try {
       _setBusyState();
-      final TokenResponse? result = await _appAuth.token(TokenRequest(
-          _clientId, _redirectUrl,
+      final TokenResponse? result = await _appAuth.token(TokenRequest(_clientId, _redirectUrl,
           authorizationCode: _authorizationCode,
           discoveryUrl: _discoveryUrl,
           codeVerifier: _codeVerifier,
@@ -204,8 +190,14 @@ class _MyAppState extends State<MyApp> {
       _setBusyState();
       // use the discovery endpoint to find the configuration
       final AuthorizationResponse? result = await _appAuth.authorize(
-        AuthorizationRequest(_clientId, _redirectUrl,
-            discoveryUrl: _discoveryUrl, scopes: _scopes, loginHint: 'bob'),
+        AuthorizationRequest(
+          _clientId,
+          _redirectUrl,
+          discoveryUrl: _discoveryUrl,
+          scopes: _scopes,
+          loginHint: 'bob',
+          nonce: 'some_nonce',
+        ),
       );
 
       // or just use the issuer
@@ -225,14 +217,12 @@ class _MyAppState extends State<MyApp> {
     }
   }
 
-  Future<void> _signInWithAutoCodeExchange(
-      {bool preferEphemeralSession = false}) async {
+  Future<void> _signInWithAutoCodeExchange({bool preferEphemeralSession = false}) async {
     try {
       _setBusyState();
 
       // show that we can also explicitly specify the endpoints rather than getting from the details from the discovery document
-      final AuthorizationTokenResponse? result =
-          await _appAuth.authorizeAndExchangeCode(
+      final AuthorizationTokenResponse? result = await _appAuth.authorizeAndExchangeCode(
         AuthorizationTokenRequest(
           _clientId,
           _redirectUrl,
@@ -276,8 +266,7 @@ class _MyAppState extends State<MyApp> {
       _accessToken = _accessTokenTextController.text = response.accessToken!;
       _idToken = _idTokenTextController.text = response.idToken!;
       _refreshToken = _refreshTokenTextController.text = response.refreshToken!;
-      _accessTokenExpirationTextController.text =
-          response.accessTokenExpirationDateTime!.toIso8601String();
+      _accessTokenExpirationTextController.text = response.accessTokenExpirationDateTime!.toIso8601String();
     });
   }
 
@@ -286,8 +275,7 @@ class _MyAppState extends State<MyApp> {
       // save the code verifier and nonce as it must be used when exchanging the token
       _codeVerifier = response.codeVerifier;
       _nonce = response.nonce;
-      _authorizationCode =
-          _authorizationCodeTextController.text = response.authorizationCode!;
+      _authorizationCode = _authorizationCodeTextController.text = response.authorizationCode!;
       _isBusy = false;
     });
   }
@@ -297,14 +285,12 @@ class _MyAppState extends State<MyApp> {
       _accessToken = _accessTokenTextController.text = response!.accessToken!;
       _idToken = _idTokenTextController.text = response.idToken!;
       _refreshToken = _refreshTokenTextController.text = response.refreshToken!;
-      _accessTokenExpirationTextController.text =
-          response.accessTokenExpirationDateTime!.toIso8601String();
+      _accessTokenExpirationTextController.text = response.accessTokenExpirationDateTime!.toIso8601String();
     });
   }
 
   Future<void> _testApi(TokenResponse? response) async {
-    final http.Response httpResponse = await http.get(
-        Uri.parse('https://demo.duendesoftware.com/api/test'),
+    final http.Response httpResponse = await http.get(Uri.parse('https://demo.duendesoftware.com/api/test'),
         headers: <String, String>{'Authorization': 'Bearer $_accessToken'});
     setState(() {
       _userInfo = httpResponse.statusCode == 200 ? httpResponse.body : '';

--- a/flutter_appauth/ios/Classes/AppAuthIOSAuthorization.m
+++ b/flutter_appauth/ios/Classes/AppAuthIOSAuthorization.m
@@ -2,15 +2,24 @@
 
 @implementation AppAuthIOSAuthorization
 
-- (id<OIDExternalUserAgentSession>) performAuthorization:(OIDServiceConfiguration *)serviceConfiguration clientId:(NSString*)clientId clientSecret:(NSString*)clientSecret scopes:(NSArray *)scopes redirectUrl:(NSString*)redirectUrl additionalParameters:(NSDictionary *)additionalParameters preferEphemeralSession:(BOOL)preferEphemeralSession result:(FlutterResult)result exchangeCode:(BOOL)exchangeCode{
+- (id<OIDExternalUserAgentSession>) performAuthorization:(OIDServiceConfiguration *)serviceConfiguration clientId:(NSString*)clientId clientSecret:(NSString*)clientSecret scopes:(NSArray *)scopes redirectUrl:(NSString*)redirectUrl additionalParameters:(NSDictionary *)additionalParameters preferEphemeralSession:(BOOL)preferEphemeralSession result:(FlutterResult)result exchangeCode:(BOOL)exchangeCode nonce:(nullable NSString*)nonce{
+  NSString *codeVerifier = [OIDAuthorizationRequest generateCodeVerifier];
+  NSString *codeChallenge = [OIDAuthorizationRequest codeChallengeS256ForVerifier:codeVerifier];
+
   OIDAuthorizationRequest *request =
   [[OIDAuthorizationRequest alloc] initWithConfiguration:serviceConfiguration
                                                 clientId:clientId
-                                            clientSecret:clientSecret
-                                                  scopes:scopes
-                                             redirectURL:[NSURL URLWithString:redirectUrl]
-                                            responseType:OIDResponseTypeCode
-                                    additionalParameters:additionalParameters];
+                                                clientSecret:clientSecret
+                                                scope:[OIDScopeUtilities scopesWithArray:scopes]
+                                                redirectURL:[NSURL URLWithString:redirectUrl]
+                                                responseType:OIDResponseTypeCode
+                                                state:[OIDAuthorizationRequest generateState]
+                                                nonce: nonce != nil ? nonce : [OIDAuthorizationRequest generateState]
+                                                codeVerifier:codeVerifier
+                                                codeChallenge:codeChallenge
+                                                codeChallengeMethod:OIDOAuthorizationRequestCodeChallengeMethodS256
+                                                additionalParameters:additionalParameters];
+
   UIViewController *rootViewController =
   [UIApplication sharedApplication].delegate.window.rootViewController;
   if(exchangeCode) {

--- a/flutter_appauth/ios/Classes/FlutterAppAuth.h
+++ b/flutter_appauth/ios/Classes/FlutterAppAuth.h
@@ -43,7 +43,7 @@ static NSString *const END_SESSION_ERROR_MESSAGE_FORMAT = @"Failed to end sessio
 
 @interface AppAuthAuthorization : NSObject
 
-- (id<OIDExternalUserAgentSession>)performAuthorization:(OIDServiceConfiguration *)serviceConfiguration clientId:(NSString*)clientId clientSecret:(NSString*)clientSecret scopes:(NSArray *)scopes redirectUrl:(NSString*)redirectUrl additionalParameters:(NSDictionary *)additionalParameters preferEphemeralSession:(BOOL)preferEphemeralSession result:(FlutterResult)result exchangeCode:(BOOL)exchangeCode;
+- (id<OIDExternalUserAgentSession>)performAuthorization:(OIDServiceConfiguration *)serviceConfiguration clientId:(NSString*)clientId clientSecret:(NSString*)clientSecret scopes:(NSArray *)scopes redirectUrl:(NSString*)redirectUrl additionalParameters:(NSDictionary *)additionalParameters preferEphemeralSession:(BOOL)preferEphemeralSession result:(FlutterResult)result exchangeCode:(BOOL)exchangeCode nonce:(nullable NSString*)nonce;
 
 - (id<OIDExternalUserAgentSession>)performEndSessionRequest:(OIDServiceConfiguration *)serviceConfiguration requestParameters:(EndSessionRequestParameters *)requestParameters result:(FlutterResult)result;
 

--- a/flutter_appauth/ios/Classes/FlutterAppAuth.m
+++ b/flutter_appauth/ios/Classes/FlutterAppAuth.m
@@ -50,7 +50,7 @@
 
 @implementation AppAuthAuthorization
 
-- (id<OIDExternalUserAgentSession>)performAuthorization:(OIDServiceConfiguration *)serviceConfiguration clientId:(NSString*)clientId clientSecret:(NSString*)clientSecret scopes:(NSArray *)scopes redirectUrl:(NSString*)redirectUrl additionalParameters:(NSDictionary *)additionalParameters preferEphemeralSession:(BOOL)preferEphemeralSession result:(FlutterResult)result exchangeCode:(BOOL)exchangeCode {
+- (id<OIDExternalUserAgentSession>)performAuthorization:(OIDServiceConfiguration *)serviceConfiguration clientId:(NSString*)clientId clientSecret:(NSString*)clientSecret scopes:(NSArray *)scopes redirectUrl:(NSString*)redirectUrl additionalParameters:(NSDictionary *)additionalParameters preferEphemeralSession:(BOOL)preferEphemeralSession result:(FlutterResult)result exchangeCode:(BOOL)exchangeCode nonce:(nullable NSString*)nonce{
     return nil;
 }
 

--- a/flutter_appauth/ios/Classes/FlutterAppauthPlugin.m
+++ b/flutter_appauth/ios/Classes/FlutterAppauthPlugin.m
@@ -47,6 +47,7 @@
     _serviceConfigurationParameters = [ArgumentProcessor processArgumentValue:arguments withKey:@"serviceConfiguration"];
     _additionalParameters = [ArgumentProcessor processArgumentValue:arguments withKey:@"additionalParameters"];
     _preferEphemeralSession = [[ArgumentProcessor processArgumentValue:arguments withKey:@"preferEphemeralSession"] isEqual:@YES];
+    _nonce = [ArgumentProcessor processArgumentValue:arguments withKey:@"nonce"];
 }
 
 - (id)initWithArguments:(NSDictionary *)arguments {
@@ -148,7 +149,7 @@ AppAuthAuthorization* authorization;
     }
     if(requestParameters.serviceConfigurationParameters != nil) {
         OIDServiceConfiguration *serviceConfiguration = [self processServiceConfigurationParameters:requestParameters.serviceConfigurationParameters];
-        _currentAuthorizationFlow = [authorization performAuthorization:serviceConfiguration clientId:requestParameters.clientId clientSecret:requestParameters.clientSecret scopes:requestParameters.scopes redirectUrl:requestParameters.redirectUrl additionalParameters:requestParameters.additionalParameters preferEphemeralSession:requestParameters.preferEphemeralSession result:result exchangeCode:exchangeCode];
+        _currentAuthorizationFlow = [authorization performAuthorization:serviceConfiguration clientId:requestParameters.clientId clientSecret:requestParameters.clientSecret scopes:requestParameters.scopes redirectUrl:requestParameters.redirectUrl additionalParameters:requestParameters.additionalParameters preferEphemeralSession:requestParameters.preferEphemeralSession result:result exchangeCode:exchangeCode nonce:requestParameters.nonce];
     } else if (requestParameters.discoveryUrl) {
         NSURL *discoveryUrl = [NSURL URLWithString:requestParameters.discoveryUrl];
         [OIDAuthorizationService discoverServiceConfigurationForDiscoveryURL:discoveryUrl
@@ -160,7 +161,7 @@ AppAuthAuthorization* authorization;
                 return;
             }
             
-            self->_currentAuthorizationFlow = [authorization performAuthorization:configuration clientId:requestParameters.clientId clientSecret:requestParameters.clientSecret scopes:requestParameters.scopes redirectUrl:requestParameters.redirectUrl additionalParameters:requestParameters.additionalParameters preferEphemeralSession:requestParameters.preferEphemeralSession result:result exchangeCode:exchangeCode];
+            self->_currentAuthorizationFlow = [authorization performAuthorization:configuration clientId:requestParameters.clientId clientSecret:requestParameters.clientSecret scopes:requestParameters.scopes redirectUrl:requestParameters.redirectUrl additionalParameters:requestParameters.additionalParameters preferEphemeralSession:requestParameters.preferEphemeralSession result:result exchangeCode:exchangeCode nonce:requestParameters.nonce];
         }];
     } else {
         NSURL *issuerUrl = [NSURL URLWithString:requestParameters.issuer];
@@ -173,7 +174,7 @@ AppAuthAuthorization* authorization;
                 return;
             }
             
-            self->_currentAuthorizationFlow = [authorization performAuthorization:configuration clientId:requestParameters.clientId clientSecret:requestParameters.clientSecret scopes:requestParameters.scopes redirectUrl:requestParameters.redirectUrl additionalParameters:requestParameters.additionalParameters preferEphemeralSession:requestParameters.preferEphemeralSession result:result exchangeCode:exchangeCode];
+            self->_currentAuthorizationFlow = [authorization performAuthorization:configuration clientId:requestParameters.clientId clientSecret:requestParameters.clientSecret scopes:requestParameters.scopes redirectUrl:requestParameters.redirectUrl additionalParameters:requestParameters.additionalParameters preferEphemeralSession:requestParameters.preferEphemeralSession result:result exchangeCode:exchangeCode nonce:requestParameters.nonce];
         }];
     }
 }

--- a/flutter_appauth/macos/Classes/AppAuthMacOSAuthorization.m
+++ b/flutter_appauth/macos/Classes/AppAuthMacOSAuthorization.m
@@ -2,15 +2,24 @@
 
 @implementation AppAuthMacOSAuthorization
 
-- (id<OIDExternalUserAgentSession>)performAuthorization:(OIDServiceConfiguration *)serviceConfiguration clientId:(NSString*)clientId clientSecret:(NSString*)clientSecret scopes:(NSArray *)scopes redirectUrl:(NSString*)redirectUrl additionalParameters:(NSDictionary *)additionalParameters preferEphemeralSession:(BOOL)preferEphemeralSession result:(FlutterResult)result exchangeCode:(BOOL)exchangeCode {
-    OIDAuthorizationRequest *request =
-    [[OIDAuthorizationRequest alloc] initWithConfiguration:serviceConfiguration
-                                                  clientId:clientId
-                                              clientSecret:clientSecret
-                                                    scopes:scopes
-                                               redirectURL:[NSURL URLWithString:redirectUrl]
-                                              responseType:OIDResponseTypeCode
-                                      additionalParameters:additionalParameters];
+- (id<OIDExternalUserAgentSession>)performAuthorization:(OIDServiceConfiguration *)serviceConfiguration clientId:(NSString*)clientId clientSecret:(NSString*)clientSecret scopes:(NSArray *)scopes redirectUrl:(NSString*)redirectUrl additionalParameters:(NSDictionary *)additionalParameters preferEphemeralSession:(BOOL)preferEphemeralSession result:(FlutterResult)result exchangeCode:(BOOL)exchangeCode nonce:(nullable NSString*)nonce{
+  NSString *codeVerifier = [OIDAuthorizationRequest generateCodeVerifier];
+  NSString *codeChallenge = [OIDAuthorizationRequest codeChallengeS256ForVerifier:codeVerifier];
+
+  OIDAuthorizationRequest *request =
+  [[OIDAuthorizationRequest alloc] initWithConfiguration:serviceConfiguration
+                                                clientId:clientId
+                                                clientSecret:clientSecret
+                                                scope:[OIDScopeUtilities scopesWithArray:scopes]
+                                                redirectURL:[NSURL URLWithString:redirectUrl]
+                                                responseType:OIDResponseTypeCode
+                                                state:[OIDAuthorizationRequest generateState]
+                                                nonce: nonce != nil ? nonce : [OIDAuthorizationRequest generateState]
+                                                codeVerifier:codeVerifier
+                                                codeChallenge:codeChallenge
+                                                codeChallengeMethod:OIDOAuthorizationRequestCodeChallengeMethodS256
+                                                additionalParameters:additionalParameters];
+
     NSWindow *keyWindow = [[NSApplication sharedApplication] keyWindow];
     if(exchangeCode) {
         NSObject<OIDExternalUserAgent> *agent = [self userAgentWithPresentingWindow:keyWindow useEphemeralSession:preferEphemeralSession];

--- a/flutter_appauth/pubspec.yaml
+++ b/flutter_appauth/pubspec.yaml
@@ -10,7 +10,11 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_appauth_platform_interface: ^5.0.0
+  flutter_appauth_platform_interface:
+    git:
+      url: https://github.com/biscottis/flutter_appauth
+      path: flutter_appauth_platform_interface
+      ref: 45770d99c8bb8fead0b91fbaa2a882d42a23c0d7
 
 flutter:
   plugin:

--- a/flutter_appauth_platform_interface/lib/src/authorization_request.dart
+++ b/flutter_appauth_platform_interface/lib/src/authorization_request.dart
@@ -3,8 +3,7 @@ import 'authorization_service_configuration.dart';
 import 'common_request_details.dart';
 
 /// The details of an authorization request to get an authorization code.
-class AuthorizationRequest extends CommonRequestDetails
-    with AuthorizationParameters {
+class AuthorizationRequest extends CommonRequestDetails with AuthorizationParameters {
   AuthorizationRequest(
     String clientId,
     String redirectUrl, {
@@ -18,6 +17,7 @@ class AuthorizationRequest extends CommonRequestDetails
     bool allowInsecureConnections = false,
     bool preferEphemeralSession = false,
     String? responseMode,
+    String? nonce,
   }) {
     this.clientId = clientId;
     this.redirectUrl = redirectUrl;
@@ -31,6 +31,7 @@ class AuthorizationRequest extends CommonRequestDetails
     this.allowInsecureConnections = allowInsecureConnections;
     this.preferEphemeralSession = preferEphemeralSession;
     this.responseMode = responseMode;
+    this.nonce = nonce;
     assertConfigurationInfo();
   }
 }


### PR DESCRIPTION
### Issue
- There can be specific reasons why nonce cannot be randomly generated and needs to be passed by the caller when performing auth. But passing nonce is not exposed by flutter_appauth during `FlutterAppAuth.authorize()`

### What this PR does
- Add nonce as property to `AuthorizationRequest`
- Add logic to Android, iOS and Mac to pass nonce to their respective AppAuth

### Video/Screenshots
These tests demos that the nonce passed during auth is returned from the auth server for Android and iOS

Android:

https://user-images.githubusercontent.com/73774174/174486805-c2996791-bcb3-46d2-bdb7-6b93f90d504d.mov

iOS:

https://user-images.githubusercontent.com/73774174/174486862-d714d9c0-c3ab-49d9-955f-8b781a11db03.mov


