### PR TITLE
[flutter_appauth] Support custom state for Android, iOS and Mac

### DIFF
--- a/flutter_appauth/example/lib/main.dart
+++ b/flutter_appauth/example/lib/main.dart
@@ -197,6 +197,7 @@ class _MyAppState extends State<MyApp> {
           scopes: _scopes,
           loginHint: 'bob',
           nonce: 'some_nonce',
+          state: 'abcde',
         ),
       );
 
@@ -212,7 +213,7 @@ class _MyAppState extends State<MyApp> {
       if (result != null) {
         _processAuthResponse(result);
       }
-    } catch (_) {
+    } catch (e) {
       _clearBusyState();
     }
   }
@@ -229,6 +230,8 @@ class _MyAppState extends State<MyApp> {
           serviceConfiguration: _serviceConfiguration,
           scopes: _scopes,
           preferEphemeralSession: preferEphemeralSession,
+          nonce: 'some-nonce',
+          state: '1',
         ),
       );
 
@@ -244,7 +247,7 @@ class _MyAppState extends State<MyApp> {
         _processAuthTokenResponse(result);
         await _testApi(result);
       }
-    } catch (_) {
+    } catch (e) {
       _clearBusyState();
     }
   }

--- a/flutter_appauth/ios/Classes/AppAuthIOSAuthorization.m
+++ b/flutter_appauth/ios/Classes/AppAuthIOSAuthorization.m
@@ -2,7 +2,7 @@
 
 @implementation AppAuthIOSAuthorization
 
-- (id<OIDExternalUserAgentSession>) performAuthorization:(OIDServiceConfiguration *)serviceConfiguration clientId:(NSString*)clientId clientSecret:(NSString*)clientSecret scopes:(NSArray *)scopes redirectUrl:(NSString*)redirectUrl additionalParameters:(NSDictionary *)additionalParameters preferEphemeralSession:(BOOL)preferEphemeralSession result:(FlutterResult)result exchangeCode:(BOOL)exchangeCode nonce:(nullable NSString*)nonce{
+- (id<OIDExternalUserAgentSession>) performAuthorization:(OIDServiceConfiguration *)serviceConfiguration clientId:(NSString*)clientId clientSecret:(NSString*)clientSecret scopes:(NSArray *)scopes redirectUrl:(NSString*)redirectUrl additionalParameters:(NSDictionary *)additionalParameters preferEphemeralSession:(BOOL)preferEphemeralSession result:(FlutterResult)result exchangeCode:(BOOL)exchangeCode nonce:(nullable NSString*)nonce state:(nullable NSString*)state {
   NSString *codeVerifier = [OIDAuthorizationRequest generateCodeVerifier];
   NSString *codeChallenge = [OIDAuthorizationRequest codeChallengeS256ForVerifier:codeVerifier];
 
@@ -13,7 +13,7 @@
                                                 scope:[OIDScopeUtilities scopesWithArray:scopes]
                                                 redirectURL:[NSURL URLWithString:redirectUrl]
                                                 responseType:OIDResponseTypeCode
-                                                state:[OIDAuthorizationRequest generateState]
+                                                state: state != nil ? state : [OIDAuthorizationRequest generateState]
                                                 nonce: nonce != nil ? nonce : [OIDAuthorizationRequest generateState]
                                                 codeVerifier:codeVerifier
                                                 codeChallenge:codeChallenge
@@ -42,6 +42,7 @@
               [processedResponse setObject:authorizationResponse.authorizationCode forKey:@"authorizationCode"];
               [processedResponse setObject:authorizationResponse.request.codeVerifier forKey:@"codeVerifier"];
               [processedResponse setObject:authorizationResponse.request.nonce forKey:@"nonce"];
+              [processedResponse setObject:authorizationResponse.request.state forKey:@"state"];
               result(processedResponse);
           } else {
               [FlutterAppAuth finishWithError:AUTHORIZE_ERROR_CODE message:[FlutterAppAuth formatMessageWithError:AUTHORIZE_ERROR_MESSAGE_FORMAT error:error] result:result];

--- a/flutter_appauth/ios/Classes/FlutterAppAuth.h
+++ b/flutter_appauth/ios/Classes/FlutterAppAuth.h
@@ -43,7 +43,7 @@ static NSString *const END_SESSION_ERROR_MESSAGE_FORMAT = @"Failed to end sessio
 
 @interface AppAuthAuthorization : NSObject
 
-- (id<OIDExternalUserAgentSession>)performAuthorization:(OIDServiceConfiguration *)serviceConfiguration clientId:(NSString*)clientId clientSecret:(NSString*)clientSecret scopes:(NSArray *)scopes redirectUrl:(NSString*)redirectUrl additionalParameters:(NSDictionary *)additionalParameters preferEphemeralSession:(BOOL)preferEphemeralSession result:(FlutterResult)result exchangeCode:(BOOL)exchangeCode nonce:(nullable NSString*)nonce;
+- (id<OIDExternalUserAgentSession>)performAuthorization:(OIDServiceConfiguration *)serviceConfiguration clientId:(NSString*)clientId clientSecret:(NSString*)clientSecret scopes:(NSArray *)scopes redirectUrl:(NSString*)redirectUrl additionalParameters:(NSDictionary *)additionalParameters preferEphemeralSession:(BOOL)preferEphemeralSession result:(FlutterResult)result exchangeCode:(BOOL)exchangeCode nonce:(nullable NSString*)nonce state:(nullable NSString*)state;
 
 - (id<OIDExternalUserAgentSession>)performEndSessionRequest:(OIDServiceConfiguration *)serviceConfiguration requestParameters:(EndSessionRequestParameters *)requestParameters result:(FlutterResult)result;
 

--- a/flutter_appauth/ios/Classes/FlutterAppAuth.m
+++ b/flutter_appauth/ios/Classes/FlutterAppAuth.m
@@ -17,6 +17,9 @@
         if (authResponse.request && authResponse.request.nonce) {
             [processedResponses setObject:authResponse.request.nonce forKey:@"nonce"];
         }
+        if (authResponse.request && authResponse.request.state) {
+            [processedResponses setObject:authResponse.request.state forKey:@"state"];
+        }
      }
     if(tokenResponse.additionalParameters) {
         [processedResponses setObject:tokenResponse.additionalParameters forKey:@"tokenAdditionalParameters"];
@@ -50,7 +53,7 @@
 
 @implementation AppAuthAuthorization
 
-- (id<OIDExternalUserAgentSession>)performAuthorization:(OIDServiceConfiguration *)serviceConfiguration clientId:(NSString*)clientId clientSecret:(NSString*)clientSecret scopes:(NSArray *)scopes redirectUrl:(NSString*)redirectUrl additionalParameters:(NSDictionary *)additionalParameters preferEphemeralSession:(BOOL)preferEphemeralSession result:(FlutterResult)result exchangeCode:(BOOL)exchangeCode nonce:(nullable NSString*)nonce{
+- (id<OIDExternalUserAgentSession>)performAuthorization:(OIDServiceConfiguration *)serviceConfiguration clientId:(NSString*)clientId clientSecret:(NSString*)clientSecret scopes:(NSArray *)scopes redirectUrl:(NSString*)redirectUrl additionalParameters:(NSDictionary *)additionalParameters preferEphemeralSession:(BOOL)preferEphemeralSession result:(FlutterResult)result exchangeCode:(BOOL)exchangeCode nonce:(nullable NSString*)nonce state:(nullable NSString*)state {
     return nil;
 }
 

--- a/flutter_appauth/ios/Classes/FlutterAppauthPlugin.m
+++ b/flutter_appauth/ios/Classes/FlutterAppauthPlugin.m
@@ -29,6 +29,7 @@
 @property(nonatomic, strong) NSDictionary *serviceConfigurationParameters;
 @property(nonatomic, strong) NSDictionary *additionalParameters;
 @property(nonatomic, readwrite) BOOL preferEphemeralSession;
+@property(nonatomic, strong) NSString *state;
 
 @end
 
@@ -48,6 +49,7 @@
     _additionalParameters = [ArgumentProcessor processArgumentValue:arguments withKey:@"additionalParameters"];
     _preferEphemeralSession = [[ArgumentProcessor processArgumentValue:arguments withKey:@"preferEphemeralSession"] isEqual:@YES];
     _nonce = [ArgumentProcessor processArgumentValue:arguments withKey:@"nonce"];
+    _state = [ArgumentProcessor processArgumentValue:arguments withKey:@"state"];
 }
 
 - (id)initWithArguments:(NSDictionary *)arguments {
@@ -149,7 +151,7 @@ AppAuthAuthorization* authorization;
     }
     if(requestParameters.serviceConfigurationParameters != nil) {
         OIDServiceConfiguration *serviceConfiguration = [self processServiceConfigurationParameters:requestParameters.serviceConfigurationParameters];
-        _currentAuthorizationFlow = [authorization performAuthorization:serviceConfiguration clientId:requestParameters.clientId clientSecret:requestParameters.clientSecret scopes:requestParameters.scopes redirectUrl:requestParameters.redirectUrl additionalParameters:requestParameters.additionalParameters preferEphemeralSession:requestParameters.preferEphemeralSession result:result exchangeCode:exchangeCode nonce:requestParameters.nonce];
+        _currentAuthorizationFlow = [authorization performAuthorization:serviceConfiguration clientId:requestParameters.clientId clientSecret:requestParameters.clientSecret scopes:requestParameters.scopes redirectUrl:requestParameters.redirectUrl additionalParameters:requestParameters.additionalParameters preferEphemeralSession:requestParameters.preferEphemeralSession result:result exchangeCode:exchangeCode nonce:requestParameters.nonce state:requestParameters.state];
     } else if (requestParameters.discoveryUrl) {
         NSURL *discoveryUrl = [NSURL URLWithString:requestParameters.discoveryUrl];
         [OIDAuthorizationService discoverServiceConfigurationForDiscoveryURL:discoveryUrl
@@ -161,7 +163,7 @@ AppAuthAuthorization* authorization;
                 return;
             }
             
-            self->_currentAuthorizationFlow = [authorization performAuthorization:configuration clientId:requestParameters.clientId clientSecret:requestParameters.clientSecret scopes:requestParameters.scopes redirectUrl:requestParameters.redirectUrl additionalParameters:requestParameters.additionalParameters preferEphemeralSession:requestParameters.preferEphemeralSession result:result exchangeCode:exchangeCode nonce:requestParameters.nonce];
+            self->_currentAuthorizationFlow = [authorization performAuthorization:configuration clientId:requestParameters.clientId clientSecret:requestParameters.clientSecret scopes:requestParameters.scopes redirectUrl:requestParameters.redirectUrl additionalParameters:requestParameters.additionalParameters preferEphemeralSession:requestParameters.preferEphemeralSession result:result exchangeCode:exchangeCode nonce:requestParameters.nonce state:requestParameters.state];
         }];
     } else {
         NSURL *issuerUrl = [NSURL URLWithString:requestParameters.issuer];
@@ -174,7 +176,7 @@ AppAuthAuthorization* authorization;
                 return;
             }
             
-            self->_currentAuthorizationFlow = [authorization performAuthorization:configuration clientId:requestParameters.clientId clientSecret:requestParameters.clientSecret scopes:requestParameters.scopes redirectUrl:requestParameters.redirectUrl additionalParameters:requestParameters.additionalParameters preferEphemeralSession:requestParameters.preferEphemeralSession result:result exchangeCode:exchangeCode nonce:requestParameters.nonce];
+            self->_currentAuthorizationFlow = [authorization performAuthorization:configuration clientId:requestParameters.clientId clientSecret:requestParameters.clientSecret scopes:requestParameters.scopes redirectUrl:requestParameters.redirectUrl additionalParameters:requestParameters.additionalParameters preferEphemeralSession:requestParameters.preferEphemeralSession result:result exchangeCode:exchangeCode nonce:requestParameters.nonce state:requestParameters.state];
         }];
     }
 }

--- a/flutter_appauth/macos/Classes/AppAuthMacOSAuthorization.m
+++ b/flutter_appauth/macos/Classes/AppAuthMacOSAuthorization.m
@@ -2,7 +2,7 @@
 
 @implementation AppAuthMacOSAuthorization
 
-- (id<OIDExternalUserAgentSession>)performAuthorization:(OIDServiceConfiguration *)serviceConfiguration clientId:(NSString*)clientId clientSecret:(NSString*)clientSecret scopes:(NSArray *)scopes redirectUrl:(NSString*)redirectUrl additionalParameters:(NSDictionary *)additionalParameters preferEphemeralSession:(BOOL)preferEphemeralSession result:(FlutterResult)result exchangeCode:(BOOL)exchangeCode nonce:(nullable NSString*)nonce{
+- (id<OIDExternalUserAgentSession>)performAuthorization:(OIDServiceConfiguration *)serviceConfiguration clientId:(NSString*)clientId clientSecret:(NSString*)clientSecret scopes:(NSArray *)scopes redirectUrl:(NSString*)redirectUrl additionalParameters:(NSDictionary *)additionalParameters preferEphemeralSession:(BOOL)preferEphemeralSession result:(FlutterResult)result exchangeCode:(BOOL)exchangeCode nonce:(nullable NSString*)nonce state:(nullable NSString*)state{
   NSString *codeVerifier = [OIDAuthorizationRequest generateCodeVerifier];
   NSString *codeChallenge = [OIDAuthorizationRequest codeChallengeS256ForVerifier:codeVerifier];
 
@@ -13,7 +13,7 @@
                                                 scope:[OIDScopeUtilities scopesWithArray:scopes]
                                                 redirectURL:[NSURL URLWithString:redirectUrl]
                                                 responseType:OIDResponseTypeCode
-                                                state:[OIDAuthorizationRequest generateState]
+                                                state: state != nil ? state : [OIDAuthorizationRequest generateState]
                                                 nonce: nonce != nil ? nonce : [OIDAuthorizationRequest generateState]
                                                 codeVerifier:codeVerifier
                                                 codeChallenge:codeChallenge
@@ -41,6 +41,7 @@
                 [processedResponse setObject:authorizationResponse.authorizationCode forKey:@"authorizationCode"];
                 [processedResponse setObject:authorizationResponse.request.codeVerifier forKey:@"codeVerifier"];
                 [processedResponse setObject:authorizationResponse.request.nonce forKey:@"nonce"];
+                [processedResponse setObject:authorizationResponse.request.state forKey:@"state"];
                 result(processedResponse);
             } else {
                 [FlutterAppAuth finishWithError:AUTHORIZE_ERROR_CODE message:[FlutterAppAuth formatMessageWithError:AUTHORIZE_ERROR_MESSAGE_FORMAT error:error] result:result];

--- a/flutter_appauth/pubspec.yaml
+++ b/flutter_appauth/pubspec.yaml
@@ -11,10 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_appauth_platform_interface:
-    git:
-      url: https://github.com/biscottis/flutter_appauth
-      path: flutter_appauth_platform_interface
-      ref: 45770d99c8bb8fead0b91fbaa2a882d42a23c0d7
+    path: ../flutter_appauth_platform_interface
 
 flutter:
   plugin:

--- a/flutter_appauth/pubspec.yaml
+++ b/flutter_appauth/pubspec.yaml
@@ -11,7 +11,10 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_appauth_platform_interface:
-    path: ../flutter_appauth_platform_interface
+    git:
+      url: https://github.com/biscottis/flutter_appauth
+      path: flutter_appauth_platform_interface
+      ref: 471f1f4eab2efb0700d752f50d1fe21a9b7a8d6f
 
 flutter:
   plugin:

--- a/flutter_appauth_platform_interface/lib/src/authorization_parameters.dart
+++ b/flutter_appauth_platform_interface/lib/src/authorization_parameters.dart
@@ -11,4 +11,6 @@ mixin AuthorizationParameters {
   bool? preferEphemeralSession;
 
   String? responseMode;
+
+  String? state;
 }

--- a/flutter_appauth_platform_interface/lib/src/authorization_request.dart
+++ b/flutter_appauth_platform_interface/lib/src/authorization_request.dart
@@ -18,6 +18,7 @@ class AuthorizationRequest extends CommonRequestDetails with AuthorizationParame
     bool preferEphemeralSession = false,
     String? responseMode,
     String? nonce,
+    String? state,
   }) {
     this.clientId = clientId;
     this.redirectUrl = redirectUrl;
@@ -32,6 +33,7 @@ class AuthorizationRequest extends CommonRequestDetails with AuthorizationParame
     this.preferEphemeralSession = preferEphemeralSession;
     this.responseMode = responseMode;
     this.nonce = nonce;
+    this.state = state;
     assertConfigurationInfo();
   }
 }

--- a/flutter_appauth_platform_interface/lib/src/authorization_response.dart
+++ b/flutter_appauth_platform_interface/lib/src/authorization_response.dart
@@ -5,6 +5,7 @@ class AuthorizationResponse {
     this.codeVerifier,
     this.nonce,
     this.authorizationAdditionalParameters,
+    this.state,
   });
 
   /// The authorization code.
@@ -22,4 +23,6 @@ class AuthorizationResponse {
 
   /// Additional parameters included in the response.
   final Map<String, dynamic>? authorizationAdditionalParameters;
+
+  final String? state;
 }

--- a/flutter_appauth_platform_interface/lib/src/authorization_token_request.dart
+++ b/flutter_appauth_platform_interface/lib/src/authorization_token_request.dart
@@ -21,6 +21,7 @@ class AuthorizationTokenRequest extends TokenRequest
     bool preferEphemeralSession = false,
     String? nonce,
     String? responseMode,
+    String? state,
   }) : super(
           clientId,
           redirectUrl,
@@ -38,5 +39,6 @@ class AuthorizationTokenRequest extends TokenRequest
     this.promptValues = promptValues;
     this.preferEphemeralSession = preferEphemeralSession;
     this.responseMode = responseMode;
+    this.state = state;
   }
 }

--- a/flutter_appauth_platform_interface/lib/src/method_channel_flutter_appauth.dart
+++ b/flutter_appauth_platform_interface/lib/src/method_channel_flutter_appauth.dart
@@ -28,6 +28,7 @@ class MethodChannelFlutterAppAuth extends FlutterAppAuthPlatform {
       nonce: result['nonce'],
       authorizationAdditionalParameters:
           result['authorizationAdditionalParameters']?.cast<String, dynamic>(),
+      state: result['state'],
     );
   }
 

--- a/flutter_appauth_platform_interface/lib/src/method_channel_mappers.dart
+++ b/flutter_appauth_platform_interface/lib/src/method_channel_mappers.dart
@@ -100,5 +100,6 @@ Map<String, Object?> _convertAuthorizationParametersToMap(
     'promptValues': authorizationParameters.promptValues,
     'preferEphemeralSession': authorizationParameters.preferEphemeralSession,
     'responseMode': authorizationParameters.responseMode,
+    'state': authorizationParameters.state,
   };
 }


### PR DESCRIPTION
### Issue
- There can be specific reasons why state cannot be randomly generated and needs to be passed by the caller when performing auth

### What this PR does
- Add state as property to `AuthorizationRequest` and `AuthorizationResponse`
- Add logic to Android, iOS and Mac to pass state to their respective AppAuth

### Video/Screenshots
TBD


