### PR TITLE
update: replace message with stack trace

### DIFF
--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -25,6 +25,9 @@ import net.openid.appauth.connectivity.DefaultConnectionBuilder;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -165,7 +168,7 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
                     checkAndSetPendingOperation(call.method, result);
                     handleAuthorizeMethodCall(arguments, true);
                 } catch (Exception ex) {
-                    finishWithError(AUTHORIZE_AND_EXCHANGE_CODE_ERROR_CODE, ex.getLocalizedMessage(), getCauseFromException(ex));
+                    finishWithError(AUTHORIZE_AND_EXCHANGE_CODE_ERROR_CODE, getStringStackTraceFromException(ex), getCauseFromException(ex));
                 }
                 break;
             case AUTHORIZE_METHOD:
@@ -173,7 +176,7 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
                     checkAndSetPendingOperation(call.method, result);
                     handleAuthorizeMethodCall(arguments, false);
                 } catch (Exception ex) {
-                    finishWithError(AUTHORIZE_ERROR_CODE, ex.getLocalizedMessage(), getCauseFromException(ex));
+                    finishWithError(AUTHORIZE_ERROR_CODE, getStringStackTraceFromException(ex), getCauseFromException(ex));
                 }
                 break;
             case TOKEN_METHOD:
@@ -181,7 +184,7 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
                     checkAndSetPendingOperation(call.method, result);
                     handleTokenMethodCall(arguments);
                 } catch (Exception ex) {
-                    finishWithError(TOKEN_ERROR_CODE, ex.getLocalizedMessage(), getCauseFromException(ex));
+                    finishWithError(TOKEN_ERROR_CODE, getStringStackTraceFromException(ex), getCauseFromException(ex));
                 }
                 break;
             case END_SESSION_METHOD:
@@ -189,7 +192,7 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
                     checkAndSetPendingOperation(call.method, result);
                     handleEndSessionMethodCall(arguments);
                 } catch (Exception ex) {
-                    finishWithError(END_SESSION_ERROR_CODE, ex.getLocalizedMessage(), getCauseFromException(ex));
+                    finishWithError(END_SESSION_ERROR_CODE, getStringStackTraceFromException(ex), getCauseFromException(ex));
                 }
                 break;
             default:
@@ -498,7 +501,13 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
 
     private String getCauseFromException(Exception ex) {
         final Throwable cause = ex.getCause();
-        return cause != null ? cause.getMessage() : null;
+        return cause != null ? getStringStackTraceFromException(cause) : null;
+    }
+
+    private String getStringStackTraceFromException(Throwable ex) {
+        final Writer writer = new StringWriter();
+        ex.printStackTrace(new PrintWriter(writer));
+        return writer.toString();
     }
 
 


### PR DESCRIPTION
This will show more detailed native stack trace which easier to debug later.

example Crashlytics log : https://console.firebase.google.com/project/payfazz-android-staging/crashlytics/app/android:com.payfazz.android.staging/issues/94ee7163c000a2be6fa48cef2063f6e2?sessionEventKey=62D1551A03730001320626D9A13E73D7_1699011688753966103&versions=4.3.3-stg%20(40303)

![Screen Shot 2022-07-15 at 19 16 22](https://user-images.githubusercontent.com/30292221/179221171-ccf383d9-67e5-43f5-9b4b-16a21e0b185c.png)

```
java.lang.NullPointerException: uriString
	at android.net.Uri$StringUri.<init>(Uri.java:476)
	at android.net.Uri$StringUri.<init>(Unknown Source:0)
	at android.net.Uri.parse(Uri.java:438)
	at credoapp.private.nt0.x(FlutterAppauthPlugin.java:2)
	at credoapp.private.nt0.t(FlutterAppauthPlugin.java:4)
	at credoapp.private.nt0.onMethodCall(FlutterAppauthPlugin.java:11)
```
deobfuscated with [retrace](https://developer.android.com/studio/command-line/retrace), the result will be : 
```
java.lang.NullPointerException: uriString
        at android.net.Uri$StringUri.<init>(Uri.java:476)
        at android.net.Uri$StringUri.<init>(Unknown Source:0)
        at android.net.Uri.parse(Uri.java:438)
        at io.crossingthestreams.flutterappauth.FlutterAppauthPlugin.performAuthorization(FlutterAppauthPlugin.java:331)
        at io.crossingthestreams.flutterappauth.FlutterAppauthPlugin.handleAuthorizeMethodCall(FlutterAppauthPlugin.java:275)
        at io.crossingthestreams.flutterappauth.FlutterAppauthPlugin.onMethodCall(FlutterAppauthPlugin.java:169)
istantyo@istantyos-MacBook-Pro pma_main_app % 
```