### PR TITLE
[PMA-1788] update: send auth exception error code

### DIFF
--- a/flutter_appauth/android/build.gradle
+++ b/flutter_appauth/android/build.gradle
@@ -35,4 +35,11 @@ android {
 
 dependencies {
     implementation 'net.openid:appauth:0.11.1'
+
+    // Import the BoM for the Firebase platform
+    implementation platform('com.google.firebase:firebase-bom:30.2.0')
+
+    // Declare the dependencies for the Crashlytics and Analytics libraries
+    // When using the BoM, you don't specify versions in Firebase library dependencies
+    implementation 'com.google.firebase:firebase-crashlytics'
 }

--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -168,7 +168,7 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
                     handleAuthorizeMethodCall(arguments, true);
                 } catch (Exception ex) {
                     FirebaseCrashlytics.getInstance().recordException(ex);
-                    finishWithError(AUTHORIZE_AND_EXCHANGE_CODE_ERROR_CODE, ex.getLocalizedMessage(), getCauseFromException(ex));
+                    finishWithUnknownError(AUTHORIZE_AND_EXCHANGE_CODE_ERROR_CODE, ex);
                 }
                 break;
             case AUTHORIZE_METHOD:
@@ -177,7 +177,7 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
                     handleAuthorizeMethodCall(arguments, false);
                 } catch (Exception ex) {
                     FirebaseCrashlytics.getInstance().recordException(ex);
-                    finishWithError(AUTHORIZE_ERROR_CODE, ex.getLocalizedMessage(), getCauseFromException(ex));
+                    finishWithUnknownError(AUTHORIZE_ERROR_CODE, ex);
                 }
                 break;
             case TOKEN_METHOD:
@@ -186,7 +186,7 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
                     handleTokenMethodCall(arguments);
                 } catch (Exception ex) {
                     FirebaseCrashlytics.getInstance().recordException(ex);
-                    finishWithError(TOKEN_ERROR_CODE, ex.getLocalizedMessage(), getCauseFromException(ex));
+                    finishWithUnknownError(TOKEN_ERROR_CODE, ex);
                 }
                 break;
             case END_SESSION_METHOD:
@@ -195,7 +195,7 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
                     handleEndSessionMethodCall(arguments);
                 } catch (Exception ex) {
                     FirebaseCrashlytics.getInstance().recordException(ex);
-                    finishWithError(END_SESSION_ERROR_CODE, ex.getLocalizedMessage(), getCauseFromException(ex));
+                    finishWithUnknownError(END_SESSION_ERROR_CODE, ex);
                 }
                 break;
             default:
@@ -476,7 +476,8 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
     }
 
     private void finishWithTokenError(AuthorizationException ex) {
-        finishWithError(TOKEN_ERROR_CODE, String.format(TOKEN_ERROR_MESSAGE_FORMAT, ex.error, ex.errorDescription), getCauseFromException(ex));
+        String errorCode = String.format("%s:%s", TOKEN_ERROR_CODE, ex.code);
+        finishWithError(errorCode, String.format(TOKEN_ERROR_MESSAGE_FORMAT, ex.error, ex.errorDescription), getCauseFromException(ex));
     }
 
 
@@ -494,13 +495,21 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
         }
     }
 
+    private void finishWithUnknownError(String appAuthErrorCode, Exception ex) {
+        String errorCode = (ex instanceof AuthorizationException)
+                ? String.format("%s:%s", appAuthErrorCode, ((AuthorizationException) ex).code)
+                : appAuthErrorCode;
+        finishWithError(errorCode, ex.getLocalizedMessage(), getCauseFromException(ex));
+    }
 
     private void finishWithDiscoveryError(AuthorizationException ex) {
-        finishWithError(DISCOVERY_ERROR_CODE, String.format(DISCOVERY_ERROR_MESSAGE_FORMAT, ex.error, ex.errorDescription), getCauseFromException(ex));
+        String errorCode = String.format("%s:%s", DISCOVERY_ERROR_CODE, ex.code);
+        finishWithError(errorCode, String.format(DISCOVERY_ERROR_MESSAGE_FORMAT, ex.error, ex.errorDescription), getCauseFromException(ex));
     }
 
     private void finishWithEndSessionError(AuthorizationException ex) {
-        finishWithError(END_SESSION_ERROR_CODE, String.format(END_SESSION_ERROR_MESSAGE_FORMAT, ex.error, ex.errorDescription), getCauseFromException(ex));
+        String errorCode = String.format("%s:%s", END_SESSION_ERROR_CODE, ex.code);
+        finishWithError(errorCode, String.format(END_SESSION_ERROR_MESSAGE_FORMAT, ex.error, ex.errorDescription), getCauseFromException(ex));
     }
 
     private String getCauseFromException(Exception ex) {
@@ -555,7 +564,8 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
                         if (resp != null) {
                             finishWithSuccess(tokenResponseToMap(resp, authResponse));
                         } else {
-                            finishWithError(AUTHORIZE_AND_EXCHANGE_CODE_ERROR_CODE, String.format(AUTHORIZE_ERROR_MESSAGE_FORMAT, ex.error, ex.errorDescription), getCauseFromException(ex));
+                            String errorCode = String.format("%s:%s", AUTHORIZE_AND_EXCHANGE_CODE_ERROR_CODE, ex.code);
+                            finishWithError(errorCode, String.format(AUTHORIZE_ERROR_MESSAGE_FORMAT, ex.error, ex.errorDescription), getCauseFromException(ex));
                         }
                     }
                 };
@@ -568,7 +578,8 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
                 finishWithSuccess(authorizationResponseToMap(authResponse));
             }
         } else {
-            finishWithError(exchangeCode ? AUTHORIZE_AND_EXCHANGE_CODE_ERROR_CODE : AUTHORIZE_ERROR_CODE, String.format(AUTHORIZE_ERROR_MESSAGE_FORMAT, authException.error, authException.errorDescription), getCauseFromException(authException));
+            String errorCode = String.format("%s:%s", exchangeCode ? AUTHORIZE_AND_EXCHANGE_CODE_ERROR_CODE : AUTHORIZE_ERROR_CODE, authException.code);
+            finishWithError(errorCode, String.format(AUTHORIZE_ERROR_MESSAGE_FORMAT, authException.error, authException.errorDescription), getCauseFromException(authException));
         }
     }
 

--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -8,6 +8,8 @@ import android.net.Uri;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.google.firebase.crashlytics.FirebaseCrashlytics;
+
 import net.openid.appauth.AppAuthConfiguration;
 import net.openid.appauth.AuthorizationException;
 import net.openid.appauth.AuthorizationRequest;
@@ -165,6 +167,7 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
                     checkAndSetPendingOperation(call.method, result);
                     handleAuthorizeMethodCall(arguments, true);
                 } catch (Exception ex) {
+                    FirebaseCrashlytics.getInstance().recordException(ex);
                     finishWithError(AUTHORIZE_AND_EXCHANGE_CODE_ERROR_CODE, ex.getLocalizedMessage(), getCauseFromException(ex));
                 }
                 break;
@@ -173,6 +176,7 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
                     checkAndSetPendingOperation(call.method, result);
                     handleAuthorizeMethodCall(arguments, false);
                 } catch (Exception ex) {
+                    FirebaseCrashlytics.getInstance().recordException(ex);
                     finishWithError(AUTHORIZE_ERROR_CODE, ex.getLocalizedMessage(), getCauseFromException(ex));
                 }
                 break;
@@ -181,6 +185,7 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
                     checkAndSetPendingOperation(call.method, result);
                     handleTokenMethodCall(arguments);
                 } catch (Exception ex) {
+                    FirebaseCrashlytics.getInstance().recordException(ex);
                     finishWithError(TOKEN_ERROR_CODE, ex.getLocalizedMessage(), getCauseFromException(ex));
                 }
                 break;
@@ -189,6 +194,7 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
                     checkAndSetPendingOperation(call.method, result);
                     handleEndSessionMethodCall(arguments);
                 } catch (Exception ex) {
+                    FirebaseCrashlytics.getInstance().recordException(ex);
                     finishWithError(END_SESSION_ERROR_CODE, ex.getLocalizedMessage(), getCauseFromException(ex));
                 }
                 break;
@@ -488,6 +494,7 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
         }
     }
 
+
     private void finishWithDiscoveryError(AuthorizationException ex) {
         finishWithError(DISCOVERY_ERROR_CODE, String.format(DISCOVERY_ERROR_MESSAGE_FORMAT, ex.error, ex.errorDescription), getCauseFromException(ex));
     }
@@ -669,4 +676,3 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
     }
 
 }
-

--- a/flutter_appauth/example/android/build.gradle
+++ b/flutter_appauth/example/android/build.gradle
@@ -6,6 +6,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.6.3'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.9.1'
     }
 }
 


### PR DESCRIPTION
### Issue
https://fazzfinancial.atlassian.net/browse/PMA-1788

### Wireframe
NA

### What this PR does
Send the [AuthorizationException](https://github.com/openid/AppAuth-Android/blob/master/library/java/net/openid/appauth/AuthorizationException.java ) `errorCode` when set error result using Result.error()

With this update the `PlatformException.code` from flutterAppAuth will be in the following form :
- if the source of exception is [AuthorizationException](https://github.com/openid/AppAuth-Android/blob/master/library/java/net/openid/appauth/AuthorizationException.java )
  PlatformException.code will be `flutterAppAuth.errorCode`:`authorizationException.errorCode`
  
  **example :** 
  ```
  PlatformException(authorize_and_exchange_code_failed:3, Failed to authorize: [error: null, description: Network error], Unable to resolve host "sso-dev.internal.xfers.com": No address associated with hostname, null)
  ```
  - `flutterAppAuth.errorCode`: `authorize_and_exchange_code_failed`
  - `authorizationException.errorCode`: 3 ([Network Error](https://github.com/openid/AppAuth-Android/blob/5966cc7efc1c7cacf78598ecae45b5e7d9365f9c/library/java/net/openid/appauth/AuthorizationException.java#L177))
  
- if the source of exception is not `AuthorizationException`, then `PlatformException.code` only have `flutterAppAuth.errorCode`
    
  **example :** 
  ```
  PlatformException(authorize_and_exchange_code_failed, null, null, null)
  ```


This update will enable to create more specific exception for authorization (rather than parse the error message or detail, which I think will be error prone)

commits:
- [pass: auth exception error code](https://github.com/biscottis/flutter_appauth/pull/5/commits/a8c726f2bd60850d55f6d932cf9240988d230ccb)

### Video/Screenshots
Example error from `AuthException` will pass the error code
![Screen Shot 2022-07-20 at 11 13 59](https://user-images.githubusercontent.com/30292221/179897486-70278c6f-12c3-495e-a8c4-bdaf13a14698.png)
