### PR TITLE
[PMA-1788] update: convert activity not found

### DIFF
--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -2,7 +2,10 @@ package io.crossingthestreams.flutterappauth;
 
 import static androidx.browser.customtabs.CustomTabsService.ACTION_CUSTOM_TABS_CONNECTION;
 
+import static net.openid.appauth.AuthorizationException.GeneralErrors.PROGRAM_CANCELED_AUTH_FLOW;
+
 import android.app.Activity;
+import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -503,9 +506,14 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
     }
 
     private void finishWithUnknownError(String appAuthErrorCode, Exception ex) {
-        String errorCode = (ex instanceof AuthorizationException)
-                ? String.format("%s:%s", appAuthErrorCode, ((AuthorizationException) ex).code)
-                : appAuthErrorCode;
+        String errorCode;
+        if (ex instanceof AuthorizationException) {
+            errorCode = String.format("%s:%s", appAuthErrorCode, ((AuthorizationException) ex).code);
+        } else if (ex instanceof ActivityNotFoundException) {
+            errorCode = String.format("%s:%s", appAuthErrorCode, PROGRAM_CANCELED_AUTH_FLOW.code);
+        } else {
+            errorCode = appAuthErrorCode;
+        }
         finishWithError(errorCode, ex.getLocalizedMessage(), getCauseFromException(ex));
     }
 

--- a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
+++ b/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java
@@ -514,7 +514,7 @@ public class FlutterAppauthPlugin implements FlutterPlugin, MethodCallHandler, P
         } else {
             errorCode = appAuthErrorCode;
         }
-        finishWithError(errorCode, ex.getLocalizedMessage(), getCauseFromException(ex));
+        finishWithError(errorCode, ex.toString(), getCauseFromException(ex));
     }
 
     private void finishWithDiscoveryError(AuthorizationException ex) {


### PR DESCRIPTION
### Issue
https://fazzfinancial.atlassian.net/browse/PMA-1788

### Wireframe
NA

### What this PR does
When **flutter-app-auth** [create an intent to open the browser](https://github.com/biscottis/flutter_appauth/blob/399f98efc11f9be1996af10fb29bb92d23eae81a/flutter_appauth/android/src/main/java/io/crossingthestreams/flutterappauth/FlutterAppauthPlugin.java#L387), there is a case that app auth library will [throw `ActivityNotFoundException` ](https://github.com/openid/AppAuth-Android/blob/5966cc7efc1c7cacf78598ecae45b5e7d9365f9c/library/java/net/openid/appauth/AuthorizationService.java#L555). 

This `ActivityNotFoundException` error will turned into `PlatformException(authorize_and_exchange_code_failed, null, null, null)` which has no useful information about the error. 

- Convert to `BrowserNotFound` error
This update will convert the error code from `authorize_and_exchange_code_failed`  into `authorize_and_exchange_code_failed:2` which can be detected as browser not found error.

- pass `toString()` method as errorMessage (for unknown error)
[`getLocalizedMessage()`](https://docs.oracle.com/javase/7/docs/api/java/lang/Throwable.html#getLocalizedMessage()) method usually not implemented (and will return null) which provide no information about the error. Meanwhile [`toString()`](https://docs.oracle.com/javase/7/docs/api/java/lang/Throwable.html#toString()) will return at least the class name.



### Video/Screenshots
- Before

https://user-images.githubusercontent.com/30292221/180687084-e698a94a-37cd-4826-8537-122846fb4cf6.mov

- After

https://user-images.githubusercontent.com/30292221/180687291-e98c8a80-25e7-46c5-9161-a770dd460ce3.mov


